### PR TITLE
Update to 1.2.6 and switch to using storage-selector

### DIFF
--- a/docs/2_circuit.md
+++ b/docs/2_circuit.md
@@ -6,7 +6,7 @@ First, build a basic circuit by connecting the RGB LED and the PIR sensor to the
 
 <span class="notes">**Note:** Before you start, put the SD card in the SD card reader on your development board.</span>
 
-Mbed Cloud requires an external storage to store the identity of the device, and to store firmware updates. This external storage does not necessarily have to be an SD card (which is too expensive to put in a production device), you can also use internal flash or external SPI flash. To modify the storage layer, you'll need to modify the [bootloader](see 'Section 8 - Firmware updates') and the application (see `SDBlockDevice sd;` in `simple-cloud-client.h`); which is not covered in this tutorial. More information is in the [Mbed Cloud docs](https://cloud.mbed.com/docs/).
+Mbed Cloud requires an external storage to store the identity of the device, and to store firmware updates. This external storage does not necessarily have to be an SD card (which is too expensive to put in a production device), you can also use internal flash or external SPI flash. To modify the storage layer, you'll need to modify the [bootloader](see 'Section 8 - Firmware updates') and the application (see `mbed_app.json` in the `connected-lights-cloud` application later in this tutorial); which is not covered in this tutorial. More information is in the [Mbed Cloud docs](https://cloud.mbed.com/docs/).
 
 #### Finding suitable pins
 

--- a/docs/4_connectivity.md
+++ b/docs/4_connectivity.md
@@ -88,12 +88,14 @@ Replace `connected-lights-cloud/source/main.cpp` with:
 
 ```cpp
 #include "mbed.h"
-#include "led.h"        // Abstracts away the differens between the LED types
 #include "easy-connect.h"
+#include "led.h"        // Abstracts away the differens between the LED types
 #include "simple-cloud-client.h"
+#include "storage-selector.h"
 
-EventQueue eventQueue;  // An event queue
-Thread eventThread;     // An RTOS thread to process events in
+EventQueue eventQueue;                  // An event queue
+Thread eventThread;                     // An RTOS thread to process events in
+FileSystem* fs = filesystem_selector(); // Mbed Cloud requires a filesystem, mount it (based on parameters in mbed_app.json)
 
 SimpleMbedClient client;
 

--- a/easy-connect.lib
+++ b/easy-connect.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/easy-connect/#bf821b0695ccada3620a6091503eb53a2a1ac3c8
+https://github.com/ARMmbed/easy-connect/#4e608305251d18851afc500dbbe704cca51db624

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#6e0d01cd13e8aca7bf4d697c3699ec9225386881
+https://github.com/ARMmbed/mbed-os/#caeaa49d68c67ee00275cece10cd88e0ed0f6ed3

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -83,6 +83,9 @@
             "platform.stdio-baud-rate": 115200,
             "platform.stdio-convert-newlines": true,
             "nanostack-hal.event_loop_thread_stack_size": 8192,
+            "storage-selector.storage": "SD_CARD",
+            "storage-selector.filesystem": "FAT",
+            "storage-selector.mount-point": "\"sd\"",
             "mbed-trace.enable": 0
         },
         "NUCLEO_F401RE": {

--- a/simple-cloud-client.lib
+++ b/simple-cloud-client.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/simple-cloud-client/#6be3fcf0a568b8a20d8e95f1c152db2b9161e615
+https://github.com/ARMmbed/simple-cloud-client/#85b350d1f3d922f7ce321f11253ad0480468e49e

--- a/simple-cloud-client.lib
+++ b/simple-cloud-client.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/simple-cloud-client/#85b350d1f3d922f7ce321f11253ad0480468e49e
+https://github.com/ARMmbed/simple-cloud-client/#a527de9a84ebaa38b36fd664d153f8c4e39b59b9


### PR DESCRIPTION
Don't rely on SD / FATFS. Update baseline libraries to be the same as mbed-cloud-client-example-restricted.

@peknis01 @iriark01 